### PR TITLE
Updates to player physics and implementation of new radiation zone prefab

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -347,6 +347,7 @@ MonoBehaviour:
   brakeRotationStrength: 0.3
   thrusterRotationStrength: 20
   maximumTorque: 45
+  rotationStrafeStrength: 200
   healthText: {fileID: 2024978895}
   playerHealth: 100
   currentThrusterAxisValue: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -350,6 +350,7 @@ MonoBehaviour:
   rotationStrafeStrength: 200
   healthText: {fileID: 2024978895}
   playerHealth: 100
+  radDmgTickRateSeconds: 1
   currentThrusterAxisValue: 0
   currentBrakeValue: 0
   currentThrusterRotateValue: 0
@@ -371,7 +372,7 @@ Rigidbody2D:
   m_GravityScale: 0
   m_Material: {fileID: 0}
   m_Interpolate: 0
-  m_SleepingMode: 1
+  m_SleepingMode: 0
   m_CollisionDetection: 0
   m_Constraints: 0
 --- !u!61 &1804189453975380236

--- a/Assets/Prefabs/Radiation Zone.prefab
+++ b/Assets/Prefabs/Radiation Zone.prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2928335260906125493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2928335260906125492}
+  - component: {fileID: 2928335260906125480}
+  - component: {fileID: 2928335260906125481}
+  - component: {fileID: 2928335260906125482}
+  - component: {fileID: 2928335260906125483}
+  m_Layer: 0
+  m_Name: Radiation Zone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2928335260906125492
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2928335260906125493}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.2, y: -0.29, z: 0.03372003}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &2928335260906125480
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2928335260906125493}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 3.17
+--- !u!58 &2928335260906125481
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2928335260906125493}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 1.65
+--- !u!58 &2928335260906125482
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2928335260906125493}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.75
+--- !u!114 &2928335260906125483
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2928335260906125493}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 008b6fa273f447e4d92ef3ae1eb088c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lowDmgTrigger: {fileID: 2928335260906125480}
+  medDmgTrigger: {fileID: 2928335260906125481}
+  highDmgTrigger: {fileID: 2928335260906125482}
+  setColliderRadiusAutomatically: 1
+  lowDmgRadius: 3.17
+  medDmgRadius: 1.65
+  highDmgRadius: 0.75
+  lowDmgValue: 2
+  medDmgValue: 4
+  highDmgValue: 6

--- a/Assets/Prefabs/Radiation Zone.prefab.meta
+++ b/Assets/Prefabs/Radiation Zone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 430c8139bd35fcc45af581183da76286
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/thielmann_test.unity
+++ b/Assets/Scenes/thielmann_test.unity
@@ -2258,10 +2258,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1804189453975380232, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}
-      propertyPath: m_AngularDrag
-      value: 0.05
-      objectReference: {fileID: 0}
     - target: {fileID: 1804189453975380233, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}
       propertyPath: m_Name
       value: Player
@@ -2309,10 +2305,6 @@ PrefabInstance:
     - target: {fileID: 1804189453975380237, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1804189453975380239, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}
-      propertyPath: rotationStrafeStrength
-      value: 200
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}

--- a/Assets/Scenes/thielmann_test.unity
+++ b/Assets/Scenes/thielmann_test.unity
@@ -1941,111 +1941,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8347613963192689499, guid: 3b3ae26f149d6d84b8397bbe3ab09980, type: 3}
   m_PrefabInstance: {fileID: 1629762010}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1668867598
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1668867599}
-  - component: {fileID: 1668867603}
-  - component: {fileID: 1668867602}
-  - component: {fileID: 1668867601}
-  - component: {fileID: 1668867600}
-  m_Layer: 0
-  m_Name: Radiation Zone
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1668867599
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1668867598}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.2, y: -0.29, z: 0.03372003}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1668867600
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1668867598}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 008b6fa273f447e4d92ef3ae1eb088c5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  lowDmgTrigger: {fileID: 1668867603}
-  medDmgTrigger: {fileID: 1668867602}
-  highDmgTrigger: {fileID: 1668867601}
-  setColliderRadiusAutomatically: 1
-  lowDmgRadius: 3.17
-  medDmgRadius: 1.65
-  highDmgRadius: 0.75
-  lowDmgValue: 2
-  medDmgValue: 4
-  highDmgValue: 6
---- !u!58 &1668867601
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1668867598}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.75
---- !u!58 &1668867602
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1668867598}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 1.65
---- !u!58 &1668867603
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1668867598}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 3.17
 --- !u!1001 &1802005053
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2424,6 +2319,63 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b91c389785febfb4fbdef4cbdc357fdd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &2928335261466599099
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.03372003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125492, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2928335260906125493, guid: 430c8139bd35fcc45af581183da76286, type: 3}
+      propertyPath: m_Name
+      value: Radiation Zone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 430c8139bd35fcc45af581183da76286, type: 3}
 --- !u!1001 &8347613964202559305
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/thielmann_test.unity
+++ b/Assets/Scenes/thielmann_test.unity
@@ -1941,6 +1941,37 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8347613963192689499, guid: 3b3ae26f149d6d84b8397bbe3ab09980, type: 3}
   m_PrefabInstance: {fileID: 1629762010}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1668867598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1668867599}
+  m_Layer: 0
+  m_Name: Radiation Zone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1668867599
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1668867598}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.16432, y: -0.27753976, z: 0.03372003}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1802005053
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/thielmann_test.unity
+++ b/Assets/Scenes/thielmann_test.unity
@@ -1950,6 +1950,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1668867599}
+  - component: {fileID: 1668867603}
+  - component: {fileID: 1668867602}
+  - component: {fileID: 1668867601}
+  - component: {fileID: 1668867600}
   m_Layer: 0
   m_Name: Radiation Zone
   m_TagString: Untagged
@@ -1965,13 +1969,83 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1668867598}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.16432, y: -0.27753976, z: 0.03372003}
+  m_LocalPosition: {x: -2.2, y: -0.29, z: 0.03372003}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1668867600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1668867598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 008b6fa273f447e4d92ef3ae1eb088c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lowDmgTrigger: {fileID: 1668867603}
+  medDmgTrigger: {fileID: 1668867602}
+  highDmgTrigger: {fileID: 1668867601}
+  setColliderRadiusAutomatically: 1
+  lowDmgRadius: 3.17
+  medDmgRadius: 1.65
+  highDmgRadius: 0.75
+  lowDmgValue: 2
+  medDmgValue: 4
+  highDmgValue: 6
+--- !u!58 &1668867601
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1668867598}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.75
+--- !u!58 &1668867602
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1668867598}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 1.65
+--- !u!58 &1668867603
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1668867598}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 3.17
 --- !u!1001 &1802005053
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/thielmann_test.unity
+++ b/Assets/Scenes/thielmann_test.unity
@@ -2258,6 +2258,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1804189453975380232, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}
+      propertyPath: m_AngularDrag
+      value: 0.05
+      objectReference: {fileID: 0}
     - target: {fileID: 1804189453975380233, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}
       propertyPath: m_Name
       value: Player
@@ -2305,6 +2309,10 @@ PrefabInstance:
     - target: {fileID: 1804189453975380237, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1804189453975380239, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}
+      propertyPath: rotationStrafeStrength
+      value: 200
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0ac484e18c4f19b4d94deee7fe395821, type: 3}

--- a/Assets/Scripts/asteroidDeadly.cs.meta
+++ b/Assets/Scripts/asteroidDeadly.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 9cd926349b05f9b4ea959810ce8aa049, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scripts/cameraController.cs
+++ b/Assets/Scripts/cameraController.cs
@@ -28,6 +28,7 @@ public class cameraController : MonoBehaviour
         pushDir = new Vector3(pushDir.x, pushDir.y, 0);
 
         transform.position += pushDir * pushStrength;
+        //switch this to lerping you fool!!
     }
 
     private void OnDrawGizmos()

--- a/Assets/Scripts/playerController.cs
+++ b/Assets/Scripts/playerController.cs
@@ -62,9 +62,6 @@ public class playerController : MonoBehaviour
         currentThrusterRotateValue = rotationAction.action.ReadValue<float>();
 
         //add forward/backward thrust
-        //TODO: play with the physics on this more, maybe figure out a way to make the horizontal momentum slow when the player rotates?
-        //apply counter thrust based on how close to 90 degrees away from velocity vector player is oriented? use dot prod of velocity and vector3.right?
-        //apply horizontal thrust when rotating might work better actually
         if (currentThrusterAxisValue != 0)
         {
             rb.AddRelativeForce(new Vector2(0, currentThrusterAxisValue * thrusterStrength * Time.deltaTime));

--- a/Assets/Scripts/playerController.cs
+++ b/Assets/Scripts/playerController.cs
@@ -25,6 +25,7 @@ public class playerController : MonoBehaviour
     public float brakeRotationStrength = .1f;
     public float thrusterRotationStrength = 5;
     public float maximumTorque = 20;
+    public float rotationStrafeStrength = 3;
 
     [Header("Player Stats")]
     public TMPro.TextMeshProUGUI healthText;
@@ -62,24 +63,32 @@ public class playerController : MonoBehaviour
 
         //add forward/backward thrust
         //TODO: play with the physics on this more, maybe figure out a way to make the horizontal momentum slow when the player rotates?
-        //apply counter thrust based on how close to 90 degrees away from velocity vector player is oriented?
+        //apply counter thrust based on how close to 90 degrees away from velocity vector player is oriented? use dot prod of velocity and vector3.right?
+        //apply horizontal thrust when rotating might work better actually
         if (currentThrusterAxisValue != 0)
         {
             rb.AddRelativeForce(new Vector2(0, currentThrusterAxisValue * thrusterStrength * Time.deltaTime));
-
-            rb.velocity = Vector2.ClampMagnitude(rb.velocity, maximumVelocity);
         }
 
         //add torque based on rotation direction input
         if (currentThrusterRotateValue != 0)
         {
             rb.AddTorque(currentThrusterRotateValue * thrusterRotationStrength * Time.deltaTime);
+            
+            //add some horizontal force when turning to keep the flying from being totally uncontrollable (hopefully)
+            rb.AddRelativeForce(Vector2.right * Mathf.Sign(currentThrusterRotateValue * -1) * rotationStrafeStrength * currentThrusterAxisValue * (rb.velocity.magnitude / maximumVelocity) * Time.deltaTime);
         }
 
         //clamp torque in general, not just when thrusting
         if (Mathf.Abs(rb.angularVelocity) > maximumTorque)
         {
             rb.angularVelocity = Mathf.Clamp(rb.angularVelocity, maximumTorque * -1, maximumTorque);
+        }
+
+        //clamp velocity in general, not just when thrusting
+        if (rb.velocity.magnitude > maximumVelocity)
+        {
+            rb.velocity = Vector2.ClampMagnitude(rb.velocity, maximumVelocity);
         }
         
         //apply counter-thrust if brake is pressed

--- a/Assets/Scripts/playerController.cs.meta
+++ b/Assets/Scripts/playerController.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 0fa69fc159d2a914296cfda9e9ead04b, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scripts/radZone.cs
+++ b/Assets/Scripts/radZone.cs
@@ -46,17 +46,18 @@ public class radZone : MonoBehaviour
 
         Collider2D playerCollider = player.GetComponent<Collider2D>();
 
+        //Apply damage based on zone player is in. Damage tick rate determined by player controller.
         if (highDmgTrigger.IsTouching(playerCollider))
         {
-            Debug.Log("Player within high rad damage zone");
+            player.applyRadDamage(highDmgValue, true);
         }
         else if (medDmgTrigger.IsTouching(playerCollider))
         {
-            Debug.Log("Player within med rad damage zone");
+            player.applyRadDamage(medDmgValue, true);
         }
         else if (lowDmgTrigger.IsTouching(playerCollider))
         {
-            Debug.Log("Player within low rad damage zone");
+            player.applyRadDamage(lowDmgValue, true);
         }
     }
 

--- a/Assets/Scripts/radZone.cs
+++ b/Assets/Scripts/radZone.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class radZone : MonoBehaviour
+{
+    [Header("Trigger references")]
+    public CircleCollider2D lowDmgTrigger;
+    public CircleCollider2D medDmgTrigger;
+    public CircleCollider2D highDmgTrigger;
+
+    [Header("Zone Radius Values")]
+    public bool setColliderRadiusAutomatically = true;
+    public float lowDmgRadius = 10;
+    public float medDmgRadius = 5;
+    public float highDmgRadius = 3;
+
+    [Header("Zone Damage Values")]
+    public float lowDmgValue = 2;
+    public float medDmgValue = 4;
+    public float highDmgValue = 6;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        if (setColliderRadiusAutomatically)
+        {
+            lowDmgTrigger.radius = lowDmgRadius;
+            medDmgTrigger.radius = medDmgRadius;
+            highDmgTrigger.radius = highDmgRadius;
+        }
+        else
+        {
+            lowDmgRadius = lowDmgTrigger.radius;
+            medDmgRadius = medDmgTrigger.radius;
+            highDmgRadius = highDmgTrigger.radius;
+        }
+    }
+
+    private void OnTriggerStay2D(Collider2D collision)
+    {
+        playerController player;
+        collision.TryGetComponent<playerController>(out player);
+        if (player == null)
+            return;
+
+        Collider2D playerCollider = player.GetComponent<Collider2D>();
+
+        if (highDmgTrigger.IsTouching(playerCollider))
+        {
+            Debug.Log("Player within high rad damage zone");
+        }
+        else if (medDmgTrigger.IsTouching(playerCollider))
+        {
+            Debug.Log("Player within med rad damage zone");
+        }
+        else if (lowDmgTrigger.IsTouching(playerCollider))
+        {
+            Debug.Log("Player within low rad damage zone");
+        }
+    }
+
+    private void OnDrawGizmos()
+    {
+        if (setColliderRadiusAutomatically)
+        {
+            lowDmgTrigger.radius = lowDmgRadius;
+            medDmgTrigger.radius = medDmgRadius;
+            highDmgTrigger.radius = highDmgRadius;
+        }
+    }
+}

--- a/Assets/Scripts/radZone.cs.meta
+++ b/Assets/Scripts/radZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 008b6fa273f447e4d92ef3ae1eb088c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
-player rotates faster
-easier to change direction while turning

-radiation zone is a single object with 3 trigger zones on it for 3 tiers of damage the player can take (more damage towards the center). 
-zones can be changed by adjusting the radius on the radZone script or by manually adjusting the colliders
-radiation damage tick rate is determined by the player controller
-as of now these zones are totally invisible in game, but can be seen in the editor with the radZone object selected and gizmos turned on